### PR TITLE
New step to send a Slack message

### DIFF
--- a/.tekton/ci/ci-listener.yml
+++ b/.tekton/ci/ci-listener.yml
@@ -135,6 +135,8 @@ spec:
             value: $(params.cpu)
           - name: memory
             value: $(params.memory)
+          - name: message
+            value: $(params.message)
         workspaces:
           - name: pipeline-ws
             persistentVolumeClaim:

--- a/.tekton/ci/ci-pipeline.yml
+++ b/.tekton/ci/ci-pipeline.yml
@@ -66,6 +66,9 @@ spec:
     - name: memory
       description: total memory of the Code Engine application
       default: "1G"
+    - name: message
+      description: the message to send to Slack
+      default: "Hello World!"
   workspaces:
     - name: pipeline-ws
   tasks:
@@ -361,3 +364,13 @@ spec:
           value: $(params.health-endpoint)
         - name: pipeline-debug
           value: $(params.pipeline-debug)
+    - name: post-to-slack
+      taskRef:
+        name: slack-post-message
+      runAfter: [git-clone]
+      params:
+        - name: message
+          value: $(params.message)
+      workspaces:
+        - name: workspace
+          workspace: pipeline-ws

--- a/.tekton/ci/ci-pipeline.yml
+++ b/.tekton/ci/ci-pipeline.yml
@@ -374,10 +374,10 @@ spec:
     - name: post-to-slack
       taskRef:
         name: slack-post-message
-      runAfter: [git-clone]
+      runAfter: [deploy-application]
       params:
         - name: message
-          value: $(params.message)
+          value: $(tasks.deploy-application.results.app-url)
       workspaces:
         - name: workspace
           workspace: pipeline-ws


### PR DESCRIPTION
This is a new step in the pipeline to send a custom Slack message specified in the Environment Variables through the key `message`.

I send the message at the `git-clone` Task to send the alert near the time the initial Slack message send for the pipeline starting.

