### PR TITLE
Update ci-listener.yml with Slack message parameter

### DIFF
--- a/.tekton/ci/ci-listener.yml
+++ b/.tekton/ci/ci-listener.yml
@@ -73,6 +73,9 @@ spec:
     - name: memory
       description: total memory of the Code Engine application
       default: "0.25G"
+    - name: message
+      description: text for Slack message
+      default: "Slack message was not provided by pipeline."
     - name: min-scale
       description: minimum scale of the Code Engine application
       default: "1"


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/openliberty.io/issues/2938

The step to send the Slack message needs to be switched from branch https://github.com/open-toolchain/tekton-catalog/tree/tkn_v1beta1 to https://github.com/open-toolchain/tekton-catalog/tree/master.

The switch is to use the new location of the container image used during the Slack message task. In this process, there is a YAML validation error indicating that the `message` parameter is undefined in the `spec`. This change is to fix that validation error so the switch to `master` branch can be configured.