### PR TITLE
Add multi-regional support to mapping Task

### DIFF
--- a/.tekton/tasks/task-publish-code-engine-deployable-mapping.yml
+++ b/.tekton/tasks/task-publish-code-engine-deployable-mapping.yml
@@ -55,87 +55,85 @@ spec:
             set -x
         fi
 
-        # SETUP BEGIN
-        ibmcloud config --check-version false
-        if [ "$(params.region)" ]; then
-          # if region is in the 'ibm:yp:<region>' format just keep the region part
-          IBM_CLOUD_REGION=$(echo "$(params.region)" | awk -F ':' '{print $NF;}')
-        else
-          IBM_CLOUD_REGION=$(jq -r '.region_id' /artifacts/_toolchain.json | awk -F: '{print $3}')
-        fi
-
-        ibmcloud login -a $(params.ibmcloud-api) -r $IBM_CLOUD_REGION --apikey $IBM_CLOUD_API_KEY
-        ibmcloud target -g $(params.resource-group)
+        # Kin: Add multi-region support
         ibmcloud plugin install code-engine
-        ibmcloud ce proj select -n $(params.code-engine-project)
-
-        DEPLOYABLE_JSON=$(ibmcloud ce app get -n $(params.app-name) -o json)
-        APPLICATION_URL=$(echo $DEPLOYABLE_JSON | jq -j '.status.url')
-
-        # Get Code Engine app ID to use as deployable mapping ID
-        DEPLOYABLE_GUID=$(ibmcloud ce app get -n $(params.app-name) -o json | jq -j '.metadata.uid')
-
-        # Update deployable mapping
-        TOOLCHAIN_ENVIRONMENT=$(jq -j '.region_id' /artifacts/_toolchain.json | awk -F: '{print $2}')
-
-        if [ "$TOOLCHAIN_ENVIRONMENT" == "ys1" ]; then
-          TOOLCHAIN_ENVIRONMENT="dev."
-        else
-          TOOLCHAIN_ENVIRONMENT=""
-        fi
-
-        TOOLCHAIN_REGION=$(jq -j '.region_id' /artifacts/_toolchain.json | awk -F: '{print $3}')
-        OTC_API_DM_URL="https://otc-api.${TOOLCHAIN_REGION}.devops.${TOOLCHAIN_ENVIRONMENT}cloud.ibm.com/api/v1/toolchain_deployable_mappings"
-        IAM_TOKEN=$(ibmcloud iam oauth-tokens --output JSON | jq -j '.iam_token')
-
-        # Check if an existing mapping exist with the given deployable guid in toolchain
-        EXISTING_MAPPING=$(curl -H "Authorization: ${IAM_TOKEN}" "${OTC_API_DM_URL}?deployable_guid=${DEPLOYABLE_GUID}")
-        MAPPING_GUID=$(echo ${EXISTING_MAPPING} | jq -j '.items[0].mapping_guid')
-
-        if [ "${MAPPING_GUID}" != "null" ]; then
-          # Delete mapping
-          curl -X DELETE -H "Authorization: ${IAM_TOKEN}" "${OTC_API_DM_URL}/${MAPPING_GUID}"
-        fi
-
-        RESOURCE_GROUP_ID=$(ibmcloud target --output JSON | jq -j '.resource_group.guid')
-
-        CONSOLE_URL=$(ibmcloud ce app get -n $(params.app-name) | grep "Console URL:" | egrep -o 'https?://[^ ]+')
-
-        # Create deployable mapping
+        MYPROJECTS=($(echo "$(params.code-engine-project)" | tr ',' '\n'))
+        MYREGIONS=($(echo "$(params.region)" | tr ',' '\n'))
+        echo -e "Targeting Code Engine projects ${MYPROJECTS[@]} in regions ${MYREGIONS[@]}"
+        for i in "${!MYPROJECTS[@]}"
+        do
+            echo "Target region ${MYREGIONS[i]}"
+            REGION=(${MYREGIONS[i]})
+            echo "Target project ${MYPROJECTS[i]}"
+            PROJECT=(${MYPROJECTS[i]})
+                    # SETUP BEGIN
+            ibmcloud config --check-version false
+            if [ "$REGION" ]; then
+                # if region is in the 'ibm:yp:<region>' format just keep the region part
+                IBM_CLOUD_REGION=$(echo "$REGION" | awk -F ':' '{print $NF;}')
+            else
+                IBM_CLOUD_REGION=$(jq -r '.region_id' /artifacts/_toolchain.json | awk -F: '{print $3}')
+            fi
+            ibmcloud login -a $(params.ibmcloud-api) -r $IBM_CLOUD_REGION --apikey $IBM_CLOUD_API_KEY
+            ibmcloud target -g $(params.resource-group)
+            ibmcloud ce proj select -n $PROJECT
+            DEPLOYABLE_JSON=$(ibmcloud ce app get -n $(params.app-name) -o json)
+            APPLICATION_URL=$(echo $DEPLOYABLE_JSON | jq -j '.status.url')
+            # Get Code Engine app ID to use as deployable mapping ID
+            DEPLOYABLE_GUID=$(ibmcloud ce app get -n $(params.app-name) -o json | jq -j '.metadata.uid')
+            # Update deployable mapping
+            TOOLCHAIN_ENVIRONMENT=$(jq -j '.region_id' /artifacts/_toolchain.json | awk -F: '{print $2}')
+            if [ "$TOOLCHAIN_ENVIRONMENT" == "ys1" ]; then
+                TOOLCHAIN_ENVIRONMENT="dev."
+            else
+                TOOLCHAIN_ENVIRONMENT=""
+            fi
+            TOOLCHAIN_REGION=$(jq -j '.region_id' /artifacts/_toolchain.json | awk -F: '{print $3}')
+            OTC_API_DM_URL="https://otc-api.${TOOLCHAIN_REGION}.devops.${TOOLCHAIN_ENVIRONMENT}cloud.ibm.com/api/v1/toolchain_deployable_mappings"
+            IAM_TOKEN=$(ibmcloud iam oauth-tokens --output JSON | jq -j '.iam_token')
+            # Check if an existing mapping exist with the given deployable guid in toolchain
+            EXISTING_MAPPING=$(curl -H "Authorization: ${IAM_TOKEN}" "${OTC_API_DM_URL}?deployable_guid=${DEPLOYABLE_GUID}")
+            MAPPING_GUID=$(echo ${EXISTING_MAPPING} | jq -j '.items[0].mapping_guid')
+            if [ "${MAPPING_GUID}" != "null" ]; then
+                # Delete mapping
+                curl -X DELETE -H "Authorization: ${IAM_TOKEN}" "${OTC_API_DM_URL}/${MAPPING_GUID}"
+            fi
+            RESOURCE_GROUP_ID=$(ibmcloud target --output JSON | jq -j '.resource_group.guid')
+            CONSOLE_URL=$(ibmcloud ce app get -n $(params.app-name) | grep "Console URL:" | egrep -o 'https?://[^ ]+')
+            # Create deployable mapping
         MAPPING_JSON=$(cat <<END
         {
-          "deployable": {
-            "deployable_guid": "${DEPLOYABLE_GUID}",
-            "type": "code_engine",
-            "container": {
-              "guid": "${RESOURCE_GROUP_ID}",
-              "type": "resource_group_id"
-            },
-            "url": [
-              "${APPLICATION_URL}",
-              "${CONSOLE_URL}"
-            ]
-          },
-          "toolchain": {
-            "toolchain_guid": "$(jq -j '.toolchain_guid' /artifacts/_toolchain.json)",
-            "region_id": "$(jq -j '.region_id' /artifacts/_toolchain.json)"
-          },
-          "source": {
-            "type": "service_instance",
-            "source_guid": "${PIPELINE_ID}"
-          }
+        "deployable": {
+        "deployable_guid": "${DEPLOYABLE_GUID}",
+        "type": "code_engine",
+        "container": {
+            "guid": "${RESOURCE_GROUP_ID}",
+            "type": "resource_group_id"
+        },
+        "url": [
+            "${APPLICATION_URL}",
+            "${CONSOLE_URL}"
+        ]
+        },
+        "toolchain": {
+        "toolchain_guid": "$(jq -j '.toolchain_guid' /artifacts/_toolchain.json)",
+        "region_id": "$(jq -j '.region_id' /artifacts/_toolchain.json)"
+        },
+        "source": {
+        "type": "service_instance",
+        "source_guid": "${PIPELINE_ID}"
+        }
         }
         END
         )
-
-        HTTP_STATUS_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Authorization: ${IAM_TOKEN}" -H "Content-Type: application/json" -d "${MAPPING_JSON}" "${OTC_API_DM_URL}")
-
-        if [ "$HTTP_STATUS_CODE" == "201" ] || [ "$HTTP_STATUS_CODE" == "204" ]; then
-          echo "Deployable mapping created/updated. HTTP Status code = $HTTP_STATUS_CODE"
-        else
-          echo "Fail to create deployable mapping ! HTTP Status code = $HTTP_STATUS_CODE"
-          exit 1
-        fi
+            HTTP_STATUS_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Authorization: ${IAM_TOKEN}" -H "Content-Type: application/json" -d "${MAPPING_JSON}" "${OTC_API_DM_URL}")
+            if [ "$HTTP_STATUS_CODE" == "201" ] || [ "$HTTP_STATUS_CODE" == "204" ]; then
+                echo "Deployable mapping created/updated. HTTP Status code = $HTTP_STATUS_CODE"
+            else
+                echo "Fail to create deployable mapping ! HTTP Status code = $HTTP_STATUS_CODE"
+                exit 1
+            fi
+        done
       volumeMounts:
         - mountPath: /cd-config
           name: cd-config-volume


### PR DESCRIPTION
The `publish-code-engine-deployable-mapping` step during build was not able to handle an array of regions as a value. The change is to add a for-loop to support 1 or many regions.